### PR TITLE
Various optimizations

### DIFF
--- a/User-Tracking/YOUR_ADMIN/includes/functions/extra_functions/user_tracking.php
+++ b/User-Tracking/YOUR_ADMIN/includes/functions/extra_functions/user_tracking.php
@@ -19,60 +19,53 @@
 // +----------------------------------------------------------------------+
 //  $Id: usertracking 2004-12-1 dave@open-operations.com http://open-operations.com
 //  UPDATED 2013-12-07 mc12345678 http://mc12345678.weebly.com
-  function zen_update_user_tracking()
-  {
+function zen_update_user_tracking()
+{
     global $db;
-    global $admin_id, $languages_id, $_GET;	
-    
-//    $skip_tracking[CONFIG_USER_TRACKING_EXCLUDED] = 1;
-        foreach(explode(",", CONFIG_USER_TRACKING_EXCLUDED) as $skip_ip)
-           {
-                      $skip_tracking[trim($skip_ip)] = 1;
-           }
-      $wo_admin_id = (int)$_SESSION['admin_id'];
-      $admin = $db->Execute("select admin_name from " . TABLE_ADMIN . " where admin_id = " . (int)$_SESSION['admin_id']);
-      $wo_full_name = $db->prepare_input($admin->fields['admin_name']);
-      $wo_session_id = $db->prepare_input(zen_session_id());
-      $wo_ip_address = $db->prepare_input(getenv('REMOTE_ADDR'));
-      $customers_host_address = $db->prepare_input($_SESSION['admin_ip_address']); // JTD:11/27/06 - added host address support
-      $wo_last_page_url = $db->prepare_input(getenv('REQUEST_URI'));
-      $referer_url = ($_SERVER['HTTP_REFERER'] == '') ? $wo_last_page_url : $_SERVER['HTTP_REFERER'];
-   $referer_url = $db->prepare_input($referer_url);
-   
-      if ($_GET['products_id']) {
-        $page_desc_values = $db->Execute("select products_name from " . TABLE_PRODUCTS_DESCRIPTION . " where products_id = " . (int)$_GET['products_id'] . " and language_id = " . (int)$languages_id);
-        $page_desc = addslashes($page_desc_values->fields['products_name']);
-      } elseif ($_GET['cPath']) {
-        $cPath = $_GET['cPath'];
-        $cPath_array = zen_parse_category_path($cPath);
-        $cPath = implode('_', $cPath_array);
-        $current_category_id = array_pop($cPath_array);
-        $page_desc_values = $db->Execute("select categories_name from " . TABLE_CATEGORIES_DESCRIPTION . " where categories_id = " . (int)$current_category_id);
-        $page_desc = addslashes($page_desc_values->fields['categories_name']);
-       } else {
-            $page_desc = addslashes(HEADING_TITLE);
-        if ($page_desc == "HEADING_TITLE") { // JTD:12/01/06 - look up configuration group name
-                $page_desc_values = $db->Execute("select configuration_group_title from " . TABLE_CONFIGURATION_GROUP . " where configuration_group_id = " . (int)$_GET['gID']);
-                $page_desc = addslashes($page_desc_values->fields['configuration_group_title']);
-                }
-       }
-	  $page_desc = $db->prepare_input($page_desc);
-	  $current_time = time();
-	
-	$user_track_array = array();
-	$user_track_array[] = array('fieldName'=>'customer_id', 'value'=>$db->prepare_input($_SESSION['admin_id']), 'type'=>'string');
-	$user_track_array[] = array('fieldName'=>'full_name', 'value'=>$wo_full_name, 'type'=>'string');
-	$user_track_array[] = array('fieldName'=>'session_id', 'value'=>$wo_session_id, 'type'=>'string');
-	$user_track_array[] = array('fieldName'=>'ip_address', 'value'=>$wo_ip_address, 'type'=>'string');
-	$user_track_array[] = array('fieldName'=>'time_entry', 'value'=>$current_time, 'type'=>'date');
-	$user_track_array[] = array('fieldName'=>'time_last_click', 'value'=>$current_time, 'type'=>'date');
-	$user_track_array[] = array('fieldName'=>'last_page_url', 'value'=>$wo_last_page_url, 'type'=>'string');
-	$user_track_array[] = array('fieldName'=>'referer_url', 'value'=>$referer_url, 'type'=>'string');
-	$user_track_array[] = array('fieldName'=>'page_desc', 'value'=>$page_desc, 'type'=>'string');
-	$user_track_array[] = array('fieldName'=>'customers_host_address', 'value'=>$customers_host_address, 'type'=>'string');
 
-	
-    if ($skip_tracking[$wo_ip_address] != 1)
-  $db->perform(TABLE_USER_TRACKING, $user_track_array);
-//      $db->Execute("insert into " . TABLE_USER_TRACKING . " (customer_id, full_name, session_id, ip_address, time_entry, time_last_click, last_page_url, referer_url, page_desc, customers_host_address) values ('" . /*$_SESSION['admin_id'] . */"', '" . /*$wo_full_name . */"', '" . /*$wo_session_id . */"', '" . /*$wo_ip_address . */"', '" . /*$current_time . "', '" . $current_time . */"', '" . /*$wo_last_page_url . */"', '" . /*$referer_url . */"', '" . /*$page_desc .*/ "', '" . /*$customers_host_address . */"')");
-  }
+//    $skip_tracking[CONFIG_USER_TRACKING_EXCLUDED] = 1;
+    foreach (explode(",", CONFIG_USER_TRACKING_EXCLUDED) as $skip_ip) {
+        $skip_tracking[trim($skip_ip)] = 1;
+    }
+    $wo_ip_address          = zen_get_ip_address(); //getenv('REMOTE_ADDR');
+    if ($skip_tracking[$wo_ip_address] == 1) return;
+
+    $wo_admin_id            = (int)$_SESSION['admin_id'];
+    $admin                  = $db->Execute("select admin_name from " . TABLE_ADMIN . " where admin_id = " . (int)$_SESSION['admin_id']);
+    $wo_full_name           = $admin->fields['admin_name'];
+    $wo_session_id          = zen_session_id();
+    $customers_host_address = $_SESSION['admin_ip_address']; // JTD:11/27/06 - added host address support
+    $wo_last_page_url       = getenv('REQUEST_URI');
+    $referer_url            = ($_SERVER['HTTP_REFERER'] == '') ? $wo_last_page_url : $_SERVER['HTTP_REFERER'];
+
+    if ($_GET['products_id']) {
+        $page_desc           = zen_get_products_name((int)$_GET['products_id']);
+    } elseif ($_GET['cPath']) {
+        $cPath_array         = zen_parse_category_path($_GET['cPath']);
+        $cPath               = implode('_', $cPath_array);
+        $current_category_id = array_pop($cPath_array);
+        $page_desc           = zen_get_categories_name((int)$current_category_id);
+    } else {
+        $page_desc = defined('HEADING_TITLE') ? HEADING_TITLE : 'CFG';
+        if ($page_desc == 'CFG') { // JTD:12/01/06 - look up configuration group name
+            $page_desc_values = $db->Execute("select configuration_group_title from " . TABLE_CONFIGURATION_GROUP . " where configuration_group_id = " . (int)$_GET['gID']);
+            $page_desc        = addslashes($page_desc_values->fields['configuration_group_title']);
+        }
+    }
+    $current_time = time();
+
+    $user_track_array = array();
+
+    $user_track_array[] = ['fieldName' => 'customer_id', 'value' => $_SESSION['admin_id'], 'type' => 'string'];
+    $user_track_array[] = ['fieldName' => 'full_name', 'value' => $wo_full_name, 'type' => 'string'];
+    $user_track_array[] = ['fieldName' => 'session_id', 'value' => $wo_session_id, 'type' => 'string'];
+    $user_track_array[] = ['fieldName' => 'ip_address', 'value' => $wo_ip_address, 'type' => 'string'];
+    $user_track_array[] = ['fieldName' => 'time_entry', 'value' => $current_time, 'type' => 'date'];
+    $user_track_array[] = ['fieldName' => 'time_last_click', 'value' => $current_time, 'type' => 'date'];
+    $user_track_array[] = ['fieldName' => 'last_page_url', 'value' => $wo_last_page_url, 'type' => 'string'];
+    $user_track_array[] = ['fieldName' => 'referer_url', 'value' => $referer_url, 'type' => 'string'];
+    $user_track_array[] = ['fieldName' => 'page_desc', 'value' => $page_desc, 'type' => 'string'];
+    $user_track_array[] = ['fieldName' => 'customers_host_address', 'value' => $customers_host_address, 'type' => 'string'];
+
+    $db->perform(TABLE_USER_TRACKING, $user_track_array);
+}

--- a/User-Tracking/YOUR_ADMIN/includes/init_includes/init_user_tracking.php
+++ b/User-Tracking/YOUR_ADMIN/includes/init_includes/init_user_tracking.php
@@ -67,14 +67,14 @@ if (is_dir($module_installer_directory)) {
   // Step through each installer file to establish the first file that matches the search criteria.
   while (substr($installers[0], strrpos($installers[0], '.')) != $file_extension || preg_match('~^[^\._].*\.php$~i', $installers[0]) <= 0 || $installers[0] == 'empty.txt') {
     unset($installers[0]);
-    if (sizeof($installers) == 0) {
+    if (count($installers) == 0) {
       break;
     }
     $installers = array_values($installers);
   }
 
   // If there are still installer files to process, then do so.
-  if (sizeof($installers) > 0) {
+  if (count($installers) > 0) {
       $newest_version = $installers[0];
       $newest_version = substr($newest_version, 0, -1 * $file_extension_len);
 
@@ -166,4 +166,3 @@ if ($zencart_com_plugin_id != 0 && SHOW_VERSION_UPDATE_IN_HEADER && (!defined($m
         $messageStack->add("Version ".$new_version_details['latest_plugin_version']." of " . $new_version_details['title'] . ' is available at <a href="' . $new_version_details['link'] . '" target="_blank">[Details]</a>', 'caution');
     }
 }
- 

--- a/User-Tracking/YOUR_ADMIN/user_tracking.php
+++ b/User-Tracking/YOUR_ADMIN/user_tracking.php
@@ -237,7 +237,7 @@
     {
 // JTD:10/27/05
 //    $db->Execute("DELETE FROM " . TABLE_USER_TRACKING . " where time_last_click < '"  . (time() - ($purge * 3600))."'");
-      $db->Execute('DELETE FROM ' . TABLE_USER_TRACKING . " WHERE time_last_click < '" . ($currentTime - (CONFIG_USER_TRACKING_PURGE_NUMBER * 60 * CONFIG_USER_TRACKING_PURGE_UNITS))."'"); //v1.4.3 2 of 15 
+      $db->Execute('DELETE FROM ' . TABLE_USER_TRACKING . " WHERE time_last_click < '" . ($currentTime - (CONFIG_USER_TRACKING_PURGE_NUMBER * 60 * CONFIG_USER_TRACKING_PURGE_UNITS))."'"); //v1.4.3 2 of 15
 
       $deleted_span_text = '<p><font color="red">' . TEXT_HAS_BEEN_PURGED . '</font></p>';
     } else {
@@ -295,8 +295,8 @@
       if ($whos_online->fields['full_name'] != 'Guest') {
         $user_tracking[$whos_online->fields['session_id']]['full_name'] = '<font color="0000ff"><b>' . $whos_online->fields['full_name'] . '</b></font>';
       }
-      
-      if (!array_key_exists('filterwordfound', $user_tracking[$whos_online->fields['session_id']])) { 
+
+      if (!array_key_exists('filterwordfound', $user_tracking[$whos_online->fields['session_id']])) {
         foreach ($user_filter_search_words as $filter_word) {
           if (stripos($whos_online->fields['last_page_url'],$filter_word) !== false) {
             $user_tracking[$whos_online->fields['session_id']]['filterwordfound'] = true;
@@ -304,7 +304,7 @@
           }
         }
       }
-      
+
       $user_tracking[$whos_online->fields['session_id']]['last_page_url'][$whos_online->fields['time_last_click']] = $whos_online->fields['last_page_url'];
 
       $user_tracking[$whos_online->fields['session_id']]['page_desc'][$whos_online->fields['time_last_click']] = $whos_online->fields['page_desc'];
@@ -484,19 +484,19 @@
                    );
   $col['header'][] = array('params' => 'class="Spiders"',
                     'align' => 'left',
-                    'text' => '<span style="white-space: nowrap;">' . zen_draw_radio_field('SpiderYes', 'HideSpiders', $displaySpider == false, NULL, ( ($displaySpider == true) ? 'onClick="this.form.submit();"' : '' ) . 'id="HideSpiders"') 
+                    'text' => '<span style="white-space: nowrap;">' . zen_draw_radio_field('SpiderYes', 'HideSpiders', $displaySpider == false, NULL, ( ($displaySpider == true) ? 'onClick="this.form.submit();"' : '' ) . 'id="HideSpiders"')
                     . TEXT_HIDE_SPIDERS . '</span>'
-                    . ' ' . '<span style="white-space: nowrap;">' . zen_draw_radio_field('SpiderYes', 'ShowSpiders', $displaySpider == true, NULL, ( ($displaySpider == false) ? 'onClick="this.form.submit();"' : '' ) . 'id="ShowSpiders"') 
+                    . ' ' . '<span style="white-space: nowrap;">' . zen_draw_radio_field('SpiderYes', 'ShowSpiders', $displaySpider == true, NULL, ( ($displaySpider == false) ? 'onClick="this.form.submit();"' : '' ) . 'id="ShowSpiders"')
                     . TEXT_SHOW_SPIDERS . '</span>'
                     . (CONFIG_USER_TRACKING_TRACK_TYPE_RECORD == '3'? TEXT_OPTION3_SPIDER_HIDE : TEXT_SPIDER_HIDE_OTHERS)
                    );
   $col['header'][] = array('params' => 'class="UserFilterSearch"',
                            'align' => 'left',
-                           'text' => '<span style="white-space: nowrap;">' . zen_draw_radio_field('UserFilteredWordSearch', 'ShowAll', $user_filter_search == 'ShowAll', NULL, (($user_filter_search !== 'ShowAll') ? 'onClick="this.form.submit();"' : '') . 'id="ShowAllFiltered"') 
+                           'text' => '<span style="white-space: nowrap;">' . zen_draw_radio_field('UserFilteredWordSearch', 'ShowAll', $user_filter_search == 'ShowAll', NULL, (($user_filter_search !== 'ShowAll') ? 'onClick="this.form.submit();"' : '') . 'id="ShowAllFiltered"')
                            . TEXT_USER_FILTER_ALL . '</span>'
-                           . ' ' . '<span style="white-space: nowrap;">' . zen_draw_radio_field('UserFilteredWordSearch', 'HideOnly', $user_filter_search == 'HideOnly', NULL, (($user_filter_search !== 'HideOnly') ? 'onClick="this.form.submit();"' : '') . 'id="HideOnlyFiltered"') 
+                           . ' ' . '<span style="white-space: nowrap;">' . zen_draw_radio_field('UserFilteredWordSearch', 'HideOnly', $user_filter_search == 'HideOnly', NULL, (($user_filter_search !== 'HideOnly') ? 'onClick="this.form.submit();"' : '') . 'id="HideOnlyFiltered"')
                            . TEXT_USER_FILTER_HIDE . '</span>'
-                           . ' ' . '<span style="white-space: nowrap;">' . zen_draw_radio_field('UserFilteredWordSearch', 'ShowOnly', $user_filter_search == 'ShowOnly', NULL, (($user_filter_search !== 'ShowOnly') ? 'onClick="this.form.submit();"' : '') . 'id="ShowOnlyFiltered"') 
+                           . ' ' . '<span style="white-space: nowrap;">' . zen_draw_radio_field('UserFilteredWordSearch', 'ShowOnly', $user_filter_search == 'ShowOnly', NULL, (($user_filter_search !== 'ShowOnly') ? 'onClick="this.form.submit();"' : '') . 'id="ShowOnlyFiltered"')
                            . TEXT_USER_FILTER_ONLY . '</span>'
                            );
   $col['header'][] = array('params' => 'class="MinView"',
@@ -626,7 +626,7 @@ foreach ($user_tracking as $ut) {
       }
       // If supposed to hide all of the users that attempted a word, then when one is found, skip to the next.
       $local_filter_found = array_key_exists('filterwordfound', $ut);
-      
+
       if ($user_filter_search == 'HideOnly' && $local_filter_found) {
         continue;
       }
@@ -639,7 +639,7 @@ foreach ($user_tracking as $ut) {
       {
         $ut['full_name'] = "Guest";
       }
-      
+
       if($ut['full_name'] != "Guest")
       {
         $stripped_name = strip_tags($ut['full_name']);
@@ -752,7 +752,7 @@ foreach ($user_tracking as $ut) {
 
       $cart = "";
       $referer_url = "";
-    //$num_sessions ++; // User Tracking - Spiders Mod 5 of 7 
+    //$num_sessions ++; // User Tracking - Spiders Mod 5 of 7
 //    $_SESSION['cart'] = array();
 
       $orig_session = $_SESSION;
@@ -775,12 +775,12 @@ foreach ($user_tracking as $ut) {
 
       if (is_object($_SESSION['cart']) /*&& sizeof($_SESSION['cart']) > 0*/) {
         $products = $_SESSION['cart']->get_products();
-        for ($i = 0, $n = sizeof($products); $i < $n; $i++) {
+        for ($i = 0, $n = count($products); $i < $n; $i++) {
           $contents[] = array('text' => $products[$i]['quantity'] . ' x ' . '<a href="' . zen_href_link(FILENAME_CATEGORIES, 'cPath=' . zen_get_product_path($products[$i]['id']) . '&pID=' . $products[$i]['id']) . '">' . $products[$i]['name'] . '</a>');
 // cPath=23&pID=74
         }
 
-        if (sizeof($products) > 0) {
+        if (count($products) > 0) {
           $contents[] = array('text' => zen_draw_separator('pixel_black.gif', '100%', '1'));
           $contents[] = array('align' => 'right', 'text'  => TEXT_SHOPPING_CART_SUBTOTAL . ' ' . $currencies->format($_SESSION['cart']->show_total(), true, $_SESSION['currency']));
         } else {
@@ -972,7 +972,7 @@ foreach ($user_tracking as $ut) {
       $boxes['visited'] = new box;
       $boxes['visited']->table_cellspacing = '1';
       $boxes['visited']->table_parameters = 'bgcolor="999999" class="UTBox"';
-      if (sizeof($row['visited']) > 0) {
+      if (count($row['visited']) > 0) {
 
 
        $col['center'][] = array('params' => 'colspan="3"',

--- a/User-Tracking/includes/auto_loaders/config.user_tracking.php
+++ b/User-Tracking/includes/auto_loaders/config.user_tracking.php
@@ -3,9 +3,9 @@
 /**
  * Autoloader array for user tracking functionality. Makes sure that user tracking is instantiated at the
  * right point of the Zen Cart initsystem.
- * 
+ *
  * @package     user_tracking
- * @author      mc12345678 
+ * @author      mc12345678
  * @copyright   Copyright 2008-2013 mc12345678
  * @copyright   Copyright 2003-2007 Zen Cart Development Team
  * @copyright   Portions Copyright 2003 osCommerce
@@ -22,5 +22,4 @@
 	'autoType' => 'classInstantiate',
 	'className' => 'user_tracking',
 	'objectName' => 'user_tracking_observe'
-	); 
-?>
+	);

--- a/User-Tracking/includes/classes/observers/class.user_tracking.php
+++ b/User-Tracking/includes/classes/observers/class.user_tracking.php
@@ -1,24 +1,38 @@
 <?php
 
 /**
- * Description of class.user_tracking
+ * Fire the user tracking logger on the appropriate notifier hooks
  *
  * @author mc12345678
  */
-class user_tracking extends base {
-  function __construct() {
-    $this->attach($this, array('NOTIFY_FOOTER_END')); 
-	}	
+class user_tracking extends base
+{
+    function __construct()
+    {
+        $this->attach($this, ['NOTIFY_FOOTER_END']);
+    }
 
-	function update(&$callingClass, $notifier, $paramsArray) {
-		if ($notifier == 'NOTIFY_FOOTER_END') {
-			/*Begin added/modified in version 1.4.3 1 of 1 */
-			if (ZEN_CONFIG_USER_TRACKING == 'true' && CONFIG_USER_TRACKING_TRACK_TYPE_RECORD == 1 && function_exists('zen_update_user_tracking')) { zen_update_user_tracking(); }
-			if (ZEN_CONFIG_USER_TRACKING == 'true' && CONFIG_USER_TRACKING_TRACK_TYPE_RECORD == 2 && function_exists('zen_update_user_tracking') && $session_started) { zen_update_user_tracking(); }
-			if (ZEN_CONFIG_USER_TRACKING == 'true' && CONFIG_USER_TRACKING_TRACK_TYPE_RECORD == 3 && function_exists('zen_update_user_tracking') && !$spider_flag) { zen_update_user_tracking(); }			
-			if (ZEN_CONFIG_USER_TRACKING == 'true' && CONFIG_USER_TRACKING_TRACK_TYPE_RECORD == 4 && function_exists('zen_update_user_tracking')) { zen_update_user_tracking(); }			
-			/*End added/modified in version 1.4.3 1 of 1 */
-		}
-	}
-	
+    function update(&$callingClass, $notifier, $paramsArray)
+    {
+        if (!defined('ZEN_CONFIG_USER_TRACKING') || ZEN_CONFIG_USER_TRACKING != 'true') return;
+        if (!function_exists('zen_update_user_tracking')) return;
+
+        if ($notifier == 'NOTIFY_FOOTER_END') {
+            global $session_started, $spider_flag;
+
+            if (CONFIG_USER_TRACKING_TRACK_TYPE_RECORD == 1) {
+                zen_update_user_tracking();
+            }
+            if (CONFIG_USER_TRACKING_TRACK_TYPE_RECORD == 2 && $session_started) {
+                zen_update_user_tracking();
+            }
+            if (CONFIG_USER_TRACKING_TRACK_TYPE_RECORD == 3 && !$spider_flag) {
+                zen_update_user_tracking();
+            }
+            if (CONFIG_USER_TRACKING_TRACK_TYPE_RECORD == 4) {
+                zen_update_user_tracking();
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
- change `sizeof` to `count` for PHP 7.2 compatibility
- remove redundant calls to `$db->prepare_input`
- use built-in ZC functions for product/cat name lookup, to leverage existing db cache optimizations
- use built-in IP address lookup , so that proxy/firewall details are honored
- code reformatting for indentation/tab/line-ending consistency
- optimize observer class to do early-returns by consolidating abort-logic